### PR TITLE
Included instantiateStreaming polyfill for iOS/Safari.

### DIFF
--- a/commands/templates/index.js
+++ b/commands/templates/index.js
@@ -6,6 +6,12 @@ const indexHTML = appName => `<!doctype html>
 	<meta charset="utf-8">
 	<script src="wasm_exec.js"></script>
 	<script>
+		if (!WebAssembly.instantiateStreaming) { // polyfill
+			WebAssembly.instantiateStreaming = async (resp, importObject) => {
+				const source = await (await resp).arrayBuffer();
+				return await WebAssembly.instantiate(source, importObject);
+			};
+		}
 		const go = new Go();
 		WebAssembly.instantiateStreaming(fetch("main.wasm"), go.importObject).then((result) => {
 			go.run(result.instance);


### PR DESCRIPTION
Fixes the following error on iOS/Safari and other platforms that lack support for instantiateStreaming.

Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming

```
TypeError: WebAssembly.instantiateStreaming is not a function.
(In 'WebAssembly.instantiateStreaming(fetch("main.wasm"), go.importObject)',
'WebAssembly.instantiateStreaming' is undefined)
```